### PR TITLE
feat: 🎸 enum の書き方を Rails 8 対応にした

### DIFF
--- a/app/models/star.rb
+++ b/app/models/star.rb
@@ -1,8 +1,8 @@
 class Star < ApplicationRecord
   has_many :characters
 
-  enum category: {
+  enum :category, {
     '天罡星三十六星': 0,
     '地煞星七十二星': 1
-  }
+  }, prefix: true
 end


### PR DESCRIPTION
This pull request includes a change to the `Star` model to improve the use of enums.

* [`app/models/star.rb`](diffhunk://#diff-1fb8cf87a0182bddcb821b1cd05038450f0c2a6599a635d5e5c66eb51fa0aa64L4-R7): Modified the `category` enum to use the new Ruby 3.0 syntax and added a prefix to the enum values.