### PR TITLE
fix: 🐛 Rails 7.2 以降で廃止される記述を適切な記述に書き換えた

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,7 +12,9 @@ rescue ActiveRecord::PendingMigrationError => e
 end
 
 RSpec.configure do |config|
-  config.fixture_path = "#{Rails.root}/spec/fixtures"
+  config.fixture_paths = [
+    "#{Rails.root}/spec/fixtures",
+  ]
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
   config.filter_rails_from_backtrace!


### PR DESCRIPTION
config.fixture_path -> config.fixture_paths
